### PR TITLE
fix(backend): Correct BusinessConfig data access - fixes BSR null issue

### DIFF
--- a/backend/app/services/business_config_service.py
+++ b/backend/app/services/business_config_service.py
@@ -83,17 +83,21 @@ class BusinessConfigService:
             try:
                 async with db_manager.session() as session:
                     # 1. Load global config
-                    global_config = await self._load_config_by_scope(session, "global")
-                    if not global_config:
+                    global_config_obj = await self._load_config_by_scope(session, "global")
+                    if global_config_obj:
+                        global_config = global_config_obj.data
+                    else:
                         global_config = await self._load_fallback_config()
-                    
+
                     # 2. Load domain override
                     domain_scope = f"domain:{domain_id}"
-                    domain_config = await self._load_config_by_scope(session, domain_scope)
-                    
-                    # 3. Load category override  
+                    domain_config_obj = await self._load_config_by_scope(session, domain_scope)
+                    domain_config = domain_config_obj.data if domain_config_obj else None
+
+                    # 3. Load category override
                     category_scope = f"category:{category}"
-                    category_config = await self._load_config_by_scope(session, category_scope)
+                    category_config_obj = await self._load_config_by_scope(session, category_scope)
+                    category_config = category_config_obj.data if category_config_obj else None
                     
                     # 4. Deep merge hierarchy
                     effective_config = self._deep_merge_configs([


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Fixes BSR returning null in production API
- Corrects BusinessConfig data access pattern to extract `.data` attribute from SQLAlchemy objects
- Resolves error: `'BusinessConfig' object has no attribute 'items'`

## Test plan
[x] Fixed code extracts `.data` attribute from BusinessConfig objects
[x] Handles None cases with ternary operators
[x] Ready for deployment to Render
[ ] Test production API after merge - BSR should return values

## Context
Production logs showed repeated errors when loading business config from DB. The service was trying to use SQLAlchemy objects directly as dictionaries without accessing their `.data` attribute. This caused fallback to hardcoded config which was missing BSR mappings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)